### PR TITLE
Fix off by one error in findFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function findFile(cwd, filename) {
   }
 
   var segs = cwd.split(path.sep);
-  var len = segs.length - 1;
+  var len = segs.length;
 
   while (len--) {
     cwd = segs.slice(0, len).join('/');

--- a/test.js
+++ b/test.js
@@ -54,6 +54,7 @@ function npm(name) {
 }
 
 describe('lookup', function () {
+
   before(function () {
     fs.writeFileSync(home + '/_aaa.txt', '');
     fs.writeFileSync(home + '/_bbb.txt', '');
@@ -90,6 +91,13 @@ describe('lookup', function () {
     actual = lookup('package.json', {cwd: cwd});
     assert.dirname(actual, cwd);
     assert.basename(actual, 'package.json');
+  });
+
+  it('should support finding file in immediate parent dir', function () {
+    cwd = path.join(__dirname, 'fixtures/a/b/c');
+    var actual = lookup('a.md', { cwd: cwd });
+    assert.dirname(actual, path.dirname(cwd));
+    assert.basename(actual, 'a.md');
   });
 
   it('should support glob patterns', function () {


### PR DESCRIPTION
Fixes off by one error which causes misses in immediate parent dir...

Example:

``` js
lookup('.babelrc', { cwd: '/a/b/c' });
```

```
/a
  /b
    /.babelrc
    /c
```

Previously the above example would return null... 
